### PR TITLE
Run the version changes on a weekly cadence

### DIFF
--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -2,7 +2,8 @@ name: Versions
 
 on:
   schedule:
-  - cron: "0 0 * * *"
+  - cron: "0 8 * * 3"
+
   push:
     paths:
       - .github/workflows/versions.yml


### PR DESCRIPTION
Running daily isn't necessary if we:

1) Don't need to keep as up-to-date as possible
2) Don't expect the dependencies to change often