### PR TITLE
Deploy to DockerHub for master builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,7 @@ jobs:
           phonito-token: ${{ secrets.PHONITO_TOKEN }}
 
       - name: Deploy to DockerHub
+        if: github.ref == 'refs/heads/master'
         run: |
-          echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }}
+          echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
           docker push ${{ steps.vars.outputs.docker_image }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,3 +48,8 @@ jobs:
         with:
           image: ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag_commit }}
           phonito-token: ${{ secrets.PHONITO_TOKEN }}
+
+      - name: Deploy to DockerHub
+        run: |
+          echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }}
+          docker push ${{ steps.vars.outputs.docker_image }}


### PR DESCRIPTION
When changes hit the master branch, they should be deployed to DockerHub with the new image. Images should only be rebuilt if changes occur to the image itself.